### PR TITLE
Fix - Remove `object.values` lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# react-outside-click-handler
+# react-outside-click-handler-lite
 
 > A React component for handling outside clicks
 
 ## Usage
 
 ```jsx
-import OutsideClickHandler from 'react-outside-click-handler';
+import OutsideClickHandler from 'react-outside-click-handler-lite';
 
 function MyComponent() {
   return (

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "airbnb-prop-types": "^2.15.0",
     "consolidated-events": "^1.1.1 || ^2.0.0",
     "document.contains": "^1.0.1",
-    "object.values": "^1.1.0",
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-outside-click-handler",
+  "name": "react-outside-click-handler-lite",
   "version": "1.3.0",
   "description": "A React component for dealing with clicks outside its subtree",
   "main": "index.js",
@@ -28,14 +28,17 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/airbnb/react-outside-click-handler.git"
+    "url": "git+https://github.com/romellem/react-outside-click-handler.git"
   },
-  "author": "Maja Wichrowska <maja.wichrowska@airbnb.com>",
+  "contributors": [
+    "Maja Wichrowska <maja.wichrowska@airbnb.com>",
+    "Matthew Wade <matt.wade@designory.com>"
+  ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/airbnb/react-outside-click-handler/issues"
+    "url": "https://github.com/romellem/react-outside-click-handler/issues"
   },
-  "homepage": "https://github.com/airbnb/react-outside-click-handler#readme",
+  "homepage": "https://github.com/romellem/react-outside-click-handler#readme",
   "devDependencies": {
     "airbnb-js-shims": "^2.2.0",
     "babel-cli": "^6.26.0",

--- a/src/OutsideClickHandler.jsx
+++ b/src/OutsideClickHandler.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 
 import { forbidExtraProps } from 'airbnb-prop-types';
 import { addEventListener } from 'consolidated-events';
-import objectValues from 'object.values';
 
 import contains from 'document.contains';
 
@@ -15,12 +14,32 @@ const DISPLAY = {
   CONTENTS: 'contents',
 };
 
+// NOTE: Of course, using a `for..in` loop as a way to determine `Object.values`
+// doesn't work for every scenario. However, since we are merely creating a plain
+// object here without weird `getters` and such, we can use this to help with
+// verifying propTypes. Doing this rather than using an polyfill'd version of the
+// real `Object.values` (such as the 'object.values' lib) reduces our bundle by a
+// fair amount, which is enough to justify the (sometimes problematic) `for..in` here.
+const pseudoObjectValues = (obj) => {
+  const objValues = [];
+  /* eslint-disable no-restricted-syntax */
+  for (const val in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, val)) {
+      objValues.push(obj[val]);
+    }
+  }
+  /* eslint-enable no-restricted-syntax */
+
+  return objValues;
+};
+const DISPLAY_VALUES = pseudoObjectValues(DISPLAY);
+
 const propTypes = forbidExtraProps({
   children: PropTypes.node.isRequired,
   onOutsideClick: PropTypes.func.isRequired,
   disabled: PropTypes.bool,
   useCapture: PropTypes.bool,
-  display: PropTypes.oneOf(objectValues(DISPLAY)),
+  display: PropTypes.oneOf(DISPLAY_VALUES),
 });
 
 const defaultProps = {
@@ -125,7 +144,7 @@ export default class OutsideClickHandler extends React.Component {
       <div
         ref={this.setChildNodeRef}
         style={
-          display !== DISPLAY.BLOCK && objectValues(DISPLAY).includes(display)
+          display !== DISPLAY.BLOCK && DISPLAY_VALUES.includes(display)
             ? { display }
             : undefined
         }


### PR DESCRIPTION
See the comment left in the main **.jsx** for the explanation of this change.

This helps to reduce the bundle size by a fair amount.